### PR TITLE
feat: styled tag using dot notation

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,10 +54,15 @@ type Tagged<T> = <P>(
 ) => ((props: P & T) => JSX.Element) & {
   className: (props: P & T) => string;
 };
-export declare function styled<T extends keyof JSX.IntrinsicElements>(
-  tag: T | ((props: JSX.IntrinsicElements[T]) => JSX.Element)
-): Tagged<JSX.IntrinsicElements[T]>;
-export declare function styled<T>(component: (props: T) => JSX.Element): Tagged<T>;
+export interface Styled {
+  <T extends keyof JSX.IntrinsicElements>(
+    tag: T | ((props: JSX.IntrinsicElements[T]) => JSX.Element)
+  ): Tagged<JSX.IntrinsicElements[T]>;
+  <T>(component: (props: T) => JSX.Element): Tagged<T>;
+}
+export declare const styled: Styled & {
+  [Tag in keyof JSX.IntrinsicElements]: Tagged<JSX.IntrinsicElements[Tag]>;
+};
 export declare function createGlobalStyles(
   tag: CSSAttribute | TemplateStringsArray | string,
   ...props: Array<string | number | Function>

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ export function ThemeProvider(props) {
 export function useTheme() {
   return useContext(ThemeContext);
 }
-export function styled(tag) {
+
+function makeStyled(tag) {
   let _ctx = this || {};
   return (...args) => {
     const Styled = props => {
@@ -68,6 +69,13 @@ export function styled(tag) {
     return Styled;
   };
 }
+
+export const styled = new Proxy(makeStyled, {
+  get(target, tag) {
+    return target(tag);
+  },
+})
+
 export function createGlobalStyles() {
   const fn = styled.call({ g: 1 }, "div").apply(null, arguments);
   return function GlobalStyles(props) {

--- a/test/test.spec.tsx
+++ b/test/test.spec.tsx
@@ -46,6 +46,20 @@ describe("Simple Styled", () => {
     })
   })
 
+  test("Creates paragraph properly using dot notation", () => {
+    const P = styled.p`
+      padding: 10px;
+      font-size: 40px;
+      border: 2px dashed tomato;
+    `;
+
+    createRoot(() => {
+      const v = (
+        <P>Content</P>
+      );
+    })
+  })
+
   test("Creates component of styled component properly", () => {
     const SuperDiv = styled("div")`
       color: red;


### PR DESCRIPTION
Added the ability to call `styled.div`, the result is the same as `styled('div')`