### PR TITLE
fix: createGlobalStyles: TypeError: fn is not a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ export const styled = new Proxy(makeStyled, {
 })
 
 export function createGlobalStyles() {
-  const fn = styled.call({ g: 1 }, "div").apply(null, arguments);
+  const fn = makeStyled.call({ g: 1 }, "div").apply(null, arguments);
   return function GlobalStyles(props) {
     fn(props);
     return null;


### PR DESCRIPTION
fixes https://github.com/solidjs/solid-styled-components/issues/19