### PR TITLE
fix(types): restrict regular styles function call to one argument

### DIFF
--- a/test/test.spec.tsx
+++ b/test/test.spec.tsx
@@ -38,6 +38,32 @@ describe("Simple Styled", () => {
     });
   });
 
+  test("Creates component properly with styles function", () => {
+    const Div = styled("div")<{ bold: boolean; border: number; color: string }>(({ bold, border, color }) => ({
+      color: "steelblue",
+      fontSize: "32px",
+      padding: "5px",
+      border: `${border}px solid ${color}`,
+      backgroundColor: "linen",
+      fontWeight: (bold ? "bold" : 100),
+    }));
+
+    createRoot(() => {
+      const v = (
+        <Div
+          aria-label="button"
+          onClick={() => {}}
+          class="test"
+          bold={true}
+          border={1}
+          color="whitesmoke"
+        >
+          Testera
+        </Div>
+      );
+    });
+  });
+
   test("Creates input properly", () => {
     const Input = styled("input")`
       width: 5em;


### PR DESCRIPTION
### What's included

fix: #37
fix: #15

Tag functions are properly typed and regular function calls are restrict to one argument (see: https://github.com/solidjs/solid-styled-components/pull/38#discussion_r988537281)
  - `keyframes`
  - `glob`
  - `css`
  - `createGlobalStyles`
  - The return of the `styled(...)`

We can now override the types to mark the `theme` as always available on the props. (see: https://github.com/solidjs/solid-styled-components/pull/38#discussion_r988531112)
