### PR TITLE
fix(types): theme optional removed (#42)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,7 +52,7 @@ export declare function ThemeProvider<
 >(props: T): JSX.Element;
 export declare function useTheme(): DefaultTheme;
 export interface ThemeProp {
-  theme?: DefaultTheme;
+  theme: DefaultTheme;
 }
 interface AsProps {
   as?: ValidComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export function setup(prefixer, shouldForwardProp = null) {
 const ThemeContext = createContext();
 export function ThemeProvider(props) {
   return createComponent(ThemeContext.Provider, {
-    value: props.theme,
+    value: props.theme || {},
     get children() {
       return props.children;
     }


### PR DESCRIPTION
<img width="498" alt="image" src="https://github.com/solidjs/solid-styled-components/assets/56449651/c6fb26ce-fced-4064-89e3-81814974af14">

Current `DefaultTheme` interface already suggests that default value for theme has to be an empty object:
`export interface DefaultTheme {}`

Enforcing this would allow users to avoid annoying non-null assertions.